### PR TITLE
Call /get endpoint instead of /pin in get_val

### DIFF
--- a/blynkapi/Blynk.py
+++ b/blynkapi/Blynk.py
@@ -59,7 +59,7 @@ class Blynk(object):
 		return self.__check(request)
 
 	def get_val(self):
-		request = Request(self.protocol+"://"+self.server+":"+self.port+"/"+self.token+"/pin/"+self.pin)
+		request = Request(self.protocol+"://"+self.server+":"+self.port+"/"+self.token+"/get/"+self.pin)
 		return self.__check(request)
 
 	def push(self, value):


### PR DESCRIPTION
Hi,

Since the last modification of this script, the Blynk REST API has changed.
The script must use `/get` instead of `/pin` to get the current value of a pin.
The old endpoint is unusable and gives a HTTP 404 error.